### PR TITLE
POSIX compatibility

### DIFF
--- a/wfs
+++ b/wfs
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Linux WAN failover script.
 #
@@ -175,13 +175,13 @@ test_single_target () {
 
         if [ "$TARGETS_FAILED" -lt "$THRESHOLD" ]
         then
-            ((TARGETS_FAILED++))
+            : $((TARGETS_FAILED=TARGETS_FAILED+1))
         fi
         TEST_INTERVAL=1
     else
         if [ "$TARGETS_FAILED" -gt "0" ]
         then
-            ((TARGETS_FAILED--))
+            : $((TARGETS_FAILED=TARGETS_FAILED-1))
         fi
 
         log DEBUG "Host $TARGET OK"
@@ -307,10 +307,10 @@ stop_wfs () {
 # cleanup works only if $DAEMON is 1
 if [ "$DAEMON" = "1" ]
 then
-    trap stop_wfs SIGINT SIGTERM
+    trap stop_wfs INT TERM
 fi
 
-if [ "$1" == "--stop" ]
+if [ "$1" = "--stop" ]
 then
     stop_wfs
     exit 0

--- a/wfs
+++ b/wfs
@@ -23,8 +23,6 @@ else
     INTERVAL=20
     TEST_COUNT=2
     THRESHOLD=3
-    COOLDOWNDELAY=20
-    TTL=""
     COOLDOWNDELAY01=3600
     COOLDOWNDELAY02=600
     MAIL_TARGET=""
@@ -47,8 +45,7 @@ NO_OF_TARGETS=ERROR
 
 # --- do not change anything below ---
 
-route -n | grep -w "$PRIMARY_GW" | grep -w "0.0.0.0" >> /dev/null 2>&1
-if [ "$?" = "0" ]
+if route -n | grep -w "$PRIMARY_GW" | grep -w "0.0.0.0" >> /dev/null 2>&1
 then
     ACTIVE_CONNECTION=PRIMARY
 else
@@ -59,7 +56,7 @@ log () {
 
     TYPE="$1"
     MSG="$2"
-    DATE=`date +%b\ %d\ %H:%M:%S`
+    DATE=$(date +%b\ %d\ %H:%M:%S)
     case "$TYPE" in
         "ERROR" )
                     log2syslog "$TYPE" "$TYPE $MSG"
@@ -89,7 +86,7 @@ log2mail () {
 
     SUBJECT="$1"
     BODY="$2"
-    DATE=`date +%b\ %d\ %H:%M:%S`
+    DATE=$(date +%b\ %d\ %H:%M:%S)
     if [ ! -z "$MAIL_TARGET" ]
     then
         echo "$DATE - $BODY" | mail -s "$SUBJECT" "$MAIL_TARGET" &
@@ -98,7 +95,7 @@ log2mail () {
 
 log2syslog () {
 
-    TYPE=`echo "$1" | awk '{print tolower($0)}'`
+    TYPE=$(echo "$1" | awk '{print tolower($0)}')
     MSG="$2"
 
     echo "$MSG" | logger -t "WFS" -p daemon."$TYPE"
@@ -111,7 +108,7 @@ init_wfs () {
         log ERROR "Targets file $TARGETS_FILE does not exist."
         exit 1
     else
-        TARGETS=`cat "$TARGETS_FILE"`
+        TARGETS=$(cat "$TARGETS_FILE")
         TMPVAR=( $TARGETS )
         NO_OF_TARGETS=${#TMPVAR[@]}
     fi
@@ -170,8 +167,7 @@ test_single_target () {
     TARGET="$1"
     log DEBUG "Test interval between hosts is $TEST_INTERVAL"
 
-    ping -W "$MAX_LATENCY" -c "$TEST_COUNT" "$TARGET" >> /dev/null 2>&1
-    if [ ! "$?" = "0" ]
+    if ! ping -W "$MAX_LATENCY" -c "$TEST_COUNT" "$TARGET" >> /dev/null 2>&1
     then
         log INFO "Host $TARGET UNREACHABLE"
 
@@ -199,7 +195,7 @@ test_wan_status () {
 
     for x in $TARGETS
     do
-        test_single_target $x
+        test_single_target "$x"
         if [ "$TARGETS_FAILED" -gt "0" ]
         then
             log INFO "Failed targets is $TARGETS_FAILED, threshold is $THRESHOLD."
@@ -255,7 +251,7 @@ switch () {
         fi
     sleep "5"
     MSG="Primary WAN link failed. Switched to secondary link."
-    BODY=`route -n`
+    BODY=$(route -n)
     log2mail "$MSG" "$BODY"
     log INFO "$MSG"
     log DEBUG "Failover Cooldown started, sleeping for $COOLDOWNDELAY01 seconds."
@@ -270,7 +266,7 @@ switch () {
         fi
     sleep "10"
     MSG="Primary WAN link OK. Switched back to primary link."
-    BODY=`route -n`
+    BODY=$(route -n)
     log2mail "$MSG" "$BODY"
     log INFO "$MSG"
     log DEBUG "Failback Cooldown started, sleeping for $COOLDOWNDELAY02 seconds."
@@ -293,9 +289,9 @@ start_wfs () {
 
 stop_wfs () {
     log INFO "Got SIGTERM, cleaning and exiting."
-    TARGETS=`cat "$TARGETS_FILE"`
+    TARGETS=$(cat "$TARGETS_FILE")
 
-    kill `cat $PIDFILE`
+    kill "$(cat $PIDFILE)"
     rm $PIDFILE
 
     if [ ! -z "$TARGETS" ]

--- a/wfs
+++ b/wfs
@@ -14,6 +14,7 @@ CONFIG_FILE="$CONFIG/wfs.conf"
 
 if [ -e "$CONFIG_FILE" ]
 then
+    # shellcheck source=/dev/null
     . $CONFIG_FILE
 else
     TARGETS_FILE="$CONFIG/targets.txt"
@@ -101,8 +102,12 @@ log2syslog () {
     echo "$MSG" | logger -t "WFS" -p daemon."$TYPE"
 }
 
+TARGETS=""
 get_targets() {
-    grep -vx '^$' "$TARGETS_FILE" | grep -v '^#'
+    if [ -z "$TARGETS" ]; then
+        TARGETS=$(grep -vx '^$' "$TARGETS_FILE" | grep -v '^#')
+    fi
+    echo "$TARGETS"| tr ' ' '\n'
 }
 
 init_wfs () {
@@ -120,7 +125,7 @@ init_wfs () {
         log ERROR "No targets to test availability, targets file $TARGETS_FILE empty?."
         exit 1
     else
-        get_targets | while read x
+        get_targets | while read -r x
         do
             log DEBUG "Adding static route for host $x"
             route add -host "$x" gw "$PRIMARY_GW" >> /dev/null 2>&1
@@ -195,7 +200,7 @@ test_single_target () {
 
 test_wan_status () {
 
-    get_targets | while read x
+    get_targets | while read -r x
     do
         test_single_target "$x"
         if [ "$TARGETS_FAILED" -gt "0" ]
@@ -295,7 +300,7 @@ stop_wfs () {
     kill "$(cat $PIDFILE)"
     rm $PIDFILE
 
-    get_targets | while read x
+    get_targets | while read -r x
     do
         log DEBUG "Removing static route for host $x"
         route del -host "$x" gw "$PRIMARY_GW" >> /dev/null 2>&1

--- a/wfs
+++ b/wfs
@@ -138,8 +138,12 @@ check_for_pid () {
 
     if [ -e "$PIDFILE" ]
     then
-        log ERROR "PID file $PIDFILE exists. Aborting."
-        exit 1
+        if [ -d "/proc/$(cat "$PIDFILE")" ]; then
+            log ERROR "PID file $PIDFILE exists. Aborting."
+            exit 1
+        else
+            rm "$PIDFILE"
+        fi
     fi
 }
 

--- a/wfs
+++ b/wfs
@@ -101,6 +101,10 @@ log2syslog () {
     echo "$MSG" | logger -t "WFS" -p daemon."$TYPE"
 }
 
+get_targets() {
+    grep -vx '^$' "$TARGETS_FILE" | grep -v '^#'
+}
+
 init_wfs () {
 
     if [ ! -e "$TARGETS_FILE" ]
@@ -108,17 +112,15 @@ init_wfs () {
         log ERROR "Targets file $TARGETS_FILE does not exist."
         exit 1
     else
-        TARGETS=$(cat "$TARGETS_FILE")
-        TMPVAR=( $TARGETS )
-        NO_OF_TARGETS=${#TMPVAR[@]}
+        NO_OF_TARGETS=$(get_targets | wc -l)
     fi
 
-    if [ -z "$TARGETS" ]
+    if [ "$NO_OF_TARGETS" = 0 ]
     then
         log ERROR "No targets to test availability, targets file $TARGETS_FILE empty?."
         exit 1
     else
-        for x in $TARGETS
+        get_targets | while read x
         do
             log DEBUG "Adding static route for host $x"
             route add -host "$x" gw "$PRIMARY_GW" >> /dev/null 2>&1
@@ -193,7 +195,7 @@ test_single_target () {
 
 test_wan_status () {
 
-    for x in $TARGETS
+    get_targets | while read x
     do
         test_single_target "$x"
         if [ "$TARGETS_FAILED" -gt "0" ]
@@ -289,19 +291,15 @@ start_wfs () {
 
 stop_wfs () {
     log INFO "Got SIGTERM, cleaning and exiting."
-    TARGETS=$(cat "$TARGETS_FILE")
 
     kill "$(cat $PIDFILE)"
     rm $PIDFILE
 
-    if [ ! -z "$TARGETS" ]
-    then
-        for x in $TARGETS
-        do
-            log DEBUG "Removing static route for host $x"
-            route del -host "$x" gw "$PRIMARY_GW" >> /dev/null 2>&1
-        done
-    fi
+    get_targets | while read x
+    do
+        log DEBUG "Removing static route for host $x"
+        route del -host "$x" gw "$PRIMARY_GW" >> /dev/null 2>&1
+    done
 
     exit 0
 }

--- a/wfs
+++ b/wfs
@@ -46,7 +46,7 @@ NO_OF_TARGETS=ERROR
 
 # --- do not change anything below ---
 
-if route -n | grep -w "$PRIMARY_GW" | grep -w "0.0.0.0" >> /dev/null 2>&1
+if route -n | grep ^"$PRIMARY_GW " | grep " 0.0.0.0 " >> /dev/null 2>&1
 then
     ACTIVE_CONNECTION=PRIMARY
 else
@@ -105,7 +105,7 @@ log2syslog () {
 TARGETS=""
 get_targets() {
     if [ -z "$TARGETS" ]; then
-        TARGETS=$(grep -vx '^$' "$TARGETS_FILE" | grep -v '^#')
+        TARGETS=$(grep -v '^$' "$TARGETS_FILE" | grep -v '^#')
     fi
     echo "$TARGETS"| tr ' ' '\n'
 }
@@ -312,7 +312,10 @@ stop_wfs () {
 # cleanup works only if $DAEMON is 1
 if [ "$DAEMON" = "1" ]
 then
-    trap stop_wfs INT TERM
+    trap stop_wfs INT
+    trap stop_wfs TERM
+else
+    trap 'exit 1' INT
 fi
 
 if [ "$1" = "--stop" ]


### PR DESCRIPTION
I recently tried to run WFS on a OpenWRT. It does not work because WFS requires bash , while I only have a posix shell.

So I tried to port WFS to standard posix shell, avoiding bashism, running through `shellcheck` and obviously testing it a bit.

The result is, I believe, quite good: most bashism were not adding anything. Some where kinda useful (the array of `$TARGETS`) but can be avoided easily.

I also used less `grep` options, so that the `busybox` implementation works (`-w` doesn't work on busybox grep).

Furthermore, I want to underline that while this is mostly a posix-shell pull request, there IS some slight change:
 * ctrl-c when running in non-daemon will now close wfs. I think this is good behavior
 * the pidfile is now checked better; if the pid written in it doesn't seeem to exist, it is removed. This is good when it is just a leftover after a bad-handled exit